### PR TITLE
Fix executables compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,15 +32,19 @@ include_directories(${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 add_executable(rb5_ros_wrapper src/wrapper.cpp src/lanros2podo.cpp)
 target_link_libraries(rb5_ros_wrapper ${catkin_LIBRARIES})
+add_dependencies(rb5_ros_wrapper ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 add_executable(rb5_update src/update.cpp src/lanpodo2ros.cpp)
 target_link_libraries(rb5_update ${catkin_LIBRARIES})
+add_dependencies(rb5_update ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 add_executable(RB5_Client src/RB5_Client.cpp)
 target_link_libraries(RB5_Client ${catkin_LIBRARIES})
+add_dependencies(RB5_Client ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 add_executable(cobot_controller src/main.cpp)
 target_link_libraries(cobot_controller ${catkin_LIBRARIES})
+add_dependencies(cobot_controller ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 catkin_package(
     CATKIN_DEPENDS

--- a/README.md
+++ b/README.md
@@ -95,20 +95,3 @@ RB5
             You can see the function calls that occur when your application receives a command packet from ROS (around line 348).
             You can see function calls such as moveJoint, moveTCP (move end effector), etc (around line 525). 
             You can see how commands are sent to the controller as well (around line 476).
-
-<br />
-
-
-------------------------------------------------------------------------------------------------------------------------------------
-
-Caution: If you receive the following error when running catkin_make
-
-         #include rb5_ros_wrapper/MotionAction.h
-
-Then follow these steps:
-<br />
-<br />
-In the CMakeLists.txt, comment out all add_executable and target_link_libraries lines using a # symbol. Run catkin_make once, then uncomment those lines and run catkin_make again.
-<br />
-<br />
-catkin_make is multithreaded by default, and it will normally try to compile the executables before generating custom messages. This will lead to compilation errors, because it is searching for a header file (MotionAction.h) that has not yet been generated. MotionAction.h contains all the custom action messages for the Action Client/Server, so by running catkin_make the first time (with the executables commented), it will generate the messages. The second catkin_make will then run smoothly, because all the message header files have been generated.

--- a/package.xml
+++ b/package.xml
@@ -7,26 +7,26 @@
   <maintainer email="kreitzjason@gmail.com"></maintainer>
 
   <license>TODO</license>
-<buildtool_depend>catkin</buildtool_depend>
-  <depend>std_msgs</depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>message_generation</build_depend>
-  <build_depend>actionlib_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>rospy</build_export_depend>
-  <build_export_depend>tf</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>rospy</exec_depend>
-  <exec_depend>tf</exec_depend>  
-  <exec_depend>message_runtime</exec_depend>
-  <exec_depend>actionlib_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
+  <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>tf</depend>
+
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>actionlib</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>urdf</build_depend>
+  <build_depend>controller_manager</build_depend>
+  <build_depend>joint_state_controller</build_depend>
+  <build_depend>robot_state_publisher</build_depend>
+  <build_depend>message_generation</build_depend>
+
+  <exec_depend>actionlib</exec_depend>
+  <exec_depend>actionlib_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
### Fixes
- add `${${PROJECT_NAME}_EXPORTED_TARGETS}` and `${catkin_EXPORTED_TARGETS}` as executables dependencies to ensure all msgs in the project are generated in advance.
- update dependency list in package.xml to ease installation with rosdep

### References
- [ROS Wiki](http://wiki.ros.org/catkin/CMakeLists.txt)
- [ROS Answers](https://answers.ros.org/question/286311/when-is-catkin_exported_targets-needed/)
- [ROS Actionlib Tutorials](https://github.com/ros/common_tutorials/blob/b3a86ff8a60efd678f942deab47efcadd52a5336/actionlib_tutorials/CMakeLists.txt#L28)